### PR TITLE
翻訳: translations.mdを日本語に翻訳

### DIFF
--- a/src/translations.md
+++ b/src/translations.md
@@ -1,13 +1,11 @@
-# Translations
+# 翻訳
 
-We are utilizing
-[mdbook-i18n-helper](https://github.com/google/mdbook-i18n-helpers). Please read
-up on how to *add* and *update* translations in
-[their repository](https://github.com/google/mdbook-i18n-helpers#creating-and-updating-translations)
+[mdbook-i18n-helper](https://github.com/google/mdbook-i18n-helpers)を利用しています。翻訳の*追加*と*更新*の方法については、
+[こちらのリポジトリ](https://github.com/google/mdbook-i18n-helpers#creating-and-updating-translations)をお読みください。
 
-## External translations
+## 外部翻訳
 
 - [简体中文](https://fomalhauthmj.github.io/patterns/)
 
-If you want to add a translation, please open an issue in the
-[main repository](https://github.com/rust-unofficial/patterns).
+翻訳を追加したい場合は、
+[メインリポジトリ](https://github.com/rust-unofficial/patterns)でissueを開いてください。


### PR DESCRIPTION
## 変更内容

`src/translations.md`を英語から日本語に翻訳しました。

## 翻訳の詳細

- 英語から日本語へ翻訳
- リンクとパスはそのまま保持
- 技術用語を適切に翻訳

Closes #52

---

🤖 Generated with [Claude Code](https://claude.ai/code)