### PR TITLE
翻訳: design-principles.md を日本語に翻訳

### DIFF
--- a/src/additional_resources/design-principles.md
+++ b/src/additional_resources/design-principles.md
@@ -1,101 +1,75 @@
-# Design principles
+# デザイン原則
 
-## A brief overview over common design principles
+## 一般的なデザイン原則の概要
 
 ---
 
 ## [SOLID](https://en.wikipedia.org/wiki/SOLID)
 
-- [Single Responsibility Principle (SRP)](https://en.wikipedia.org/wiki/Single-responsibility_principle):
-  A class should only have a single responsibility, that is, only changes to one
-  part of the software's specification should be able to affect the
-  specification of the class.
-- [Open/Closed Principle (OCP)](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle):
-  "Software entities ... should be open for extension, but closed for
-  modification."
-- [Liskov Substitution Principle (LSP)](https://en.wikipedia.org/wiki/Liskov_substitution_principle):
-  "Objects in a program should be replaceable with instances of their subtypes
-  without altering the correctness of that program."
-- [Interface Segregation Principle (ISP)](https://en.wikipedia.org/wiki/Interface_segregation_principle):
-  "Many client-specific interfaces are better than one general-purpose
-  interface."
-- [Dependency Inversion Principle (DIP)](https://en.wikipedia.org/wiki/Dependency_inversion_principle):
-  One should "depend upon abstractions, [not] concretions."
+- [単一責任の原則 (SRP)](https://en.wikipedia.org/wiki/Single-responsibility_principle):
+  クラスは単一の責任のみを持つべきです。つまり、ソフトウェア仕様の一部への変更のみが、そのクラスの仕様に影響を与えるべきです。
+- [オープン・クローズドの原則 (OCP)](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle):
+  「ソフトウェアエンティティは拡張に対して開いており、修正に対して閉じているべきです。」
+- [リスコフの置換原則 (LSP)](https://en.wikipedia.org/wiki/Liskov_substitution_principle):
+  「プログラム内のオブジェクトは、そのサブタイプのインスタンスで置き換え可能であり、プログラムの正確性を変更しないべきです。」
+- [インターフェース分離の原則 (ISP)](https://en.wikipedia.org/wiki/Interface_segregation_principle):
+  「多くのクライアント固有のインターフェースは、1つの汎用インターフェースよりも優れています。」
+- [依存性逆転の原則 (DIP)](https://en.wikipedia.org/wiki/Dependency_inversion_principle):
+  「具象ではなく、抽象に依存すべきです。」
 
-## [CRP (Composite Reuse Principle) or Composition over inheritance](https://en.wikipedia.org/wiki/Composition_over_inheritance)
+## [CRP（複合再利用の原則）または継承よりコンポジション](https://en.wikipedia.org/wiki/Composition_over_inheritance)
 
-“a the principle that classes should favor polymorphic behavior and code reuse
-by their composition (by containing instances of other classes that implement
-the desired functionality) over inheritance from a base or parent class” -
+「クラスは、基底クラスや親クラスからの継承よりも、コンポジション（望ましい機能を実装する他のクラスのインスタンスを含めること）によって、ポリモーフィックな動作とコードの再利用を優先すべきであるという原則」 -
 Knoernschild, Kirk (2002). Java Design - Objects, UML, and Process
 
-## [DRY (Don’t Repeat Yourself)](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
+## [DRY (Don't Repeat Yourself)](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
 
-"Every piece of knowledge must have a single, unambiguous, authoritative
-representation within a system"
+「すべての知識は、システム内で単一、明確、権威ある表現を持たなければならない」
 
-## [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
+## [KISS原則](https://en.wikipedia.org/wiki/KISS_principle)
 
-most systems work best if they are kept simple rather than made complicated;
-therefore, simplicity should be a key goal in design, and unnecessary complexity
-should be avoided
+ほとんどのシステムは、複雑にするよりもシンプルに保つことで最もうまく機能します。したがって、シンプルさは設計における主要な目標であるべきであり、不要な複雑さは避けるべきです。
 
-## [Law of Demeter (LoD)](https://en.wikipedia.org/wiki/Law_of_Demeter)
+## [デメテルの法則 (LoD)](https://en.wikipedia.org/wiki/Law_of_Demeter)
 
-a given object should assume as little as possible about the structure or
-properties of anything else (including its subcomponents), in accordance with
-the principle of "information hiding"
+特定のオブジェクトは、「情報隠蔽」の原則に従って、他のもの（そのサブコンポーネントを含む）の構造やプロパティについて、可能な限り少ない仮定をすべきです。
 
-## [Design by contract (DbC)](https://en.wikipedia.org/wiki/Design_by_contract)
+## [契約による設計 (DbC)](https://en.wikipedia.org/wiki/Design_by_contract)
 
-software designers should define formal, precise and verifiable interface
-specifications for software components, which extend the ordinary definition of
-abstract data types with preconditions, postconditions and invariants
+ソフトウェア設計者は、ソフトウェアコンポーネントの正式で正確かつ検証可能なインターフェース仕様を定義すべきです。これは、抽象データ型の通常の定義を、事前条件、事後条件、不変条件で拡張したものです。
 
-## [Encapsulation](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
+## [カプセル化](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
 
-bundling of data with the methods that operate on that data, or the restricting
-of direct access to some of an object's components. Encapsulation is used to
-hide the values or state of a structured data object inside a class, preventing
-unauthorized parties' direct access to them.
+データと、そのデータを操作するメソッドとのバンドリング、またはオブジェクトのコンポーネントの一部への直接アクセスの制限。カプセル化は、構造化されたデータオブジェクトの値や状態をクラス内に隠し、権限のない者による直接アクセスを防ぐために使用されます。
 
-## [Command-Query-Separation (CQS)](https://en.wikipedia.org/wiki/Command%E2%80%93query_separation)
+## [コマンド・クエリ分離 (CQS)](https://en.wikipedia.org/wiki/Command%E2%80%93query_separation)
 
-“Functions should not produce abstract side effects...only commands (procedures)
-will be permitted to produce side effects.” - Bertrand Meyer: Object-Oriented
+「関数は抽象的な副作用を生成すべきではない...コマンド（手続き）のみが副作用を生成することが許される。」 - Bertrand Meyer: Object-Oriented
 Software Construction
 
-## [Principle of least astonishment (POLA)](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)
+## [最小驚きの原則 (POLA)](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)
 
-a component of a system should behave in a way that most users will expect it to
-behave. The behavior should not astonish or surprise users
+システムのコンポーネントは、ほとんどのユーザーが期待する方法で動作すべきです。その動作はユーザーを驚かせたり、当惑させたりすべきではありません。
 
-## Linguistic-Modular-Units
+## 言語的モジュール単位
 
-“Modules must correspond to syntactic units in the language used.” - Bertrand
+「モジュールは、使用される言語の構文単位に対応しなければならない。」 - Bertrand
 Meyer: Object-Oriented Software Construction
 
-## Self-Documentation
+## 自己文書化
 
-“The designer of a module should strive to make all information about the module
-part of the module itself.” - Bertrand Meyer: Object-Oriented Software
+「モジュールの設計者は、モジュールに関するすべての情報をモジュール自体の一部にするよう努めるべきです。」 - Bertrand Meyer: Object-Oriented Software
 Construction
 
-## Uniform-Access
+## 統一アクセス
 
-“All services offered by a module should be available through a uniform
-notation, which does not betray whether they are implemented through storage or
-through computation.” - Bertrand Meyer: Object-Oriented Software Construction
+「モジュールが提供するすべてのサービスは、それらがストレージを通じて実装されているか、計算を通じて実装されているかを明かさない統一された表記法を通じて利用可能であるべきです。」 - Bertrand Meyer: Object-Oriented Software Construction
 
-## Single-Choice
+## 単一選択
 
-“Whenever a software system must support a set of alternatives, one and only one
-module in the system should know their exhaustive list.” - Bertrand Meyer:
+「ソフトウェアシステムが一連の選択肢をサポートする必要がある場合、システム内の1つのモジュールのみが、それらの完全なリストを知っているべきです。」 - Bertrand Meyer:
 Object-Oriented Software Construction
 
-## Persistence-Closure
+## 永続性クロージャ
 
-“Whenever a storage mechanism stores an object, it must store with it the
-dependents of that object. Whenever a retrieval mechanism retrieves a previously
-stored object, it must also retrieve any dependent of that object that has not
-yet been retrieved.” - Bertrand Meyer: Object-Oriented Software Construction
+「ストレージメカニズムがオブジェクトを格納するときは必ず、そのオブジェクトの依存物も一緒に格納しなければなりません。検索メカニズムが以前に格納されたオブジェクトを取り出すときは必ず、まだ取り出されていないそのオブジェクトの依存物も取り出さなければなりません。」 - Bertrand Meyer: Object-Oriented Software Construction


### PR DESCRIPTION
## 概要

`src/additional_resources/design-principles.md` を日本語に翻訳しました。

## 変更内容

- SOLID原則などの一般的なデザイン原則を日本語に翻訳
- リンクとURLは元のまま保持
- 技術用語を適切に翻訳

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)