### PR TITLE
Translate additional_resources/index.md to Japanese

### DIFF
--- a/src/additional_resources/index.md
+++ b/src/additional_resources/index.md
@@ -1,8 +1,8 @@
-# Additional resources
+# 追加リソース
 
-A collection of complementary helpful content
+補足となる有用なコンテンツのコレクション
 
-## Talks
+## 講演
 
 - [Design Patterns in Rust](https://www.youtube.com/watch?v=Pm_oO0N5B9k) by
   Nicholas Cameron at the PDRust (2016)
@@ -11,6 +11,6 @@ A collection of complementary helpful content
 - [Rust Programming Techniques](https://www.youtube.com/watch?v=vqavdUGKeb4) by
   Nicholas Cameron at LinuxConfAu (2018)
 
-## Books (Online)
+## 書籍（オンライン）
 
 - [The Rust API Guidelines](https://rust-lang.github.io/api-guidelines)


### PR DESCRIPTION
## Summary

Translated `src/additional_resources/index.md` from English to Japanese.

## Changes
- Translated title and section headers
- Translated description to natural Japanese
- Preserved all links and video titles

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)