### PR TITLE
翻訳: Iterating over an Option を日本語に翻訳

### DIFF
--- a/src/idioms/option-iter.md
+++ b/src/idioms/option-iter.md
@@ -1,15 +1,15 @@
-# Iterating over an `Option`
+# `Option`に対する反復処理
 
-## Description
+## 説明
 
-`Option` can be viewed as a container that contains either zero or one element.
-In particular, it implements the `IntoIterator` trait, and as such can be used
-with generic code that needs such a type.
+`Option`は、0個または1個の要素を含むコンテナとして見ることができます。
+特に、`IntoIterator`トレイトを実装しているため、そのような型を必要とする
+ジェネリックなコードで使用できます。
 
-## Examples
+## 例
 
-Since `Option` implements `IntoIterator`, it can be used as an argument to
-[`.extend()`](https://doc.rust-lang.org/std/iter/trait.Extend.html#tymethod.extend):
+`Option`は`IntoIterator`を実装しているため、
+[`.extend()`](https://doc.rust-lang.org/std/iter/trait.Extend.html#tymethod.extend)の引数として使用できます：
 
 ```rust
 let turing = Some("Turing");
@@ -23,9 +23,8 @@ if let Some(turing_inner) = turing {
 }
 ```
 
-If you need to tack an `Option` to the end of an existing iterator, you can pass
-it to
-[`.chain()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain):
+既存のイテレータの末尾に`Option`を追加する必要がある場合は、
+[`.chain()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain)に渡すことができます：
 
 ```rust
 let turing = Some("Turing");
@@ -36,26 +35,25 @@ for logician in logicians.iter().chain(turing.iter()) {
 }
 ```
 
-Note that if the `Option` is always `Some`, then it is more idiomatic to use
-[`std::iter::once`](https://doc.rust-lang.org/std/iter/fn.once.html) on the
-element instead.
+`Option`が常に`Some`である場合は、要素に対して
+[`std::iter::once`](https://doc.rust-lang.org/std/iter/fn.once.html)を使用する方が
+より慣用的であることに注意してください。
 
-Also, since `Option` implements `IntoIterator`, it's possible to iterate over it
-using a `for` loop. This is equivalent to matching it with `if let Some(..)`,
-and in most cases you should prefer the latter.
+また、`Option`は`IntoIterator`を実装しているため、`for`ループを使用して
+反復処理することが可能です。これは`if let Some(..)`でマッチングするのと同等ですが、
+ほとんどの場合、後者の方が望ましいでしょう。
 
-## See also
+## 参考
 
-- [`std::iter::once`](https://doc.rust-lang.org/std/iter/fn.once.html) is an
-  iterator which yields exactly one element. It's a more readable alternative to
-  `Some(foo).into_iter()`.
+- [`std::iter::once`](https://doc.rust-lang.org/std/iter/fn.once.html)は、
+  正確に1つの要素を生成するイテレータです。`Some(foo).into_iter()`よりも
+  読みやすい代替手段です。
 
-- [`Iterator::filter_map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.filter_map)
-  is a version of
-  [`Iterator::map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map),
-  specialized to mapping functions which return `Option`.
+- [`Iterator::filter_map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.filter_map)は、
+  [`Iterator::map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map)の
+  バージョンで、`Option`を返すマッピング関数に特化しています。
 
-- The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
-  for converting an `Option` to a zero- or one-element slice.
+- [`ref_slice`](https://crates.io/crates/ref_slice)クレートは、
+  `Option`を0個または1個の要素を持つスライスに変換する関数を提供します。
 
 - [Documentation for `Option<T>`](https://doc.rust-lang.org/std/option/enum.Option.html)


### PR DESCRIPTION
## 変更内容
- `src/idioms/option-iter.md` を英語から日本語へ翻訳
- コードブロックとリンクを保持
- 技術用語を適切に翻訳

Closes #26

🤖 Generated with [Claude Code](https://claude.ai/code)