### PR TITLE
翻訳: On-Stack Dynamic Dispatch を日本語に翻訳

### DIFF
--- a/src/idioms/on-stack-dyn-dispatch.md
+++ b/src/idioms/on-stack-dyn-dispatch.md
@@ -1,13 +1,10 @@
-# On-Stack Dynamic Dispatch
+# スタック上での動的ディスパッチ
 
-## Description
+## 説明
 
-We can dynamically dispatch over multiple values, however, to do so, we need to
-declare multiple variables to bind differently-typed objects. To extend the
-lifetime as necessary, we can use deferred conditional initialization, as seen
-below:
+複数の値に対して動的ディスパッチを行うことができますが、そのためには、異なる型のオブジェクトをバインドするために複数の変数を宣言する必要があります。必要に応じてライフタイムを延長するために、以下に示すように遅延条件付き初期化を使用できます：
 
-## Example
+## 例
 
 ```rust
 use std::io;
@@ -29,27 +26,19 @@ let readable: &mut dyn io::Read = if arg == "-" {
 # }
 ```
 
-## Motivation
+## 動機
 
-Rust monomorphises code by default. This means a copy of the code will be
-generated for each type it is used with and optimized independently. While this
-allows for very fast code on the hot path, it also bloats the code in places
-where performance is not of the essence, thus costing compile time and cache
-usage.
+Rustはデフォルトでコードを単相化します。これは、使用される型ごとにコードのコピーが生成され、独立して最適化されることを意味します。これによりホットパス上で非常に高速なコードが実現できますが、パフォーマンスが重要でない箇所ではコードが肥大化し、コンパイル時間とキャッシュ使用量のコストがかかります。
 
-Luckily, Rust allows us to use dynamic dispatch, but we have to explicitly ask
-for it.
+幸いにも、Rustでは動的ディスパッチを使用できますが、明示的に要求する必要があります。
 
-## Advantages
+## 利点
 
-We do not need to allocate anything on the heap. Neither do we need to
-initialize something we won't use later, nor do we need to monomorphize the
-whole code that follows to work with both `File` or `Stdin`.
+ヒープ上に何も割り当てる必要がありません。また、後で使用しないものを初期化する必要もなく、`File`または`Stdin`の両方で動作するように後続のコード全体を単相化する必要もありません。
 
-## Disadvantages
+## 欠点
 
-Before Rust 1.79.0, the code needed two `let` bindings with deferred
-initialization, which made up more moving parts than the `Box`-based version:
+Rust 1.79.0以前では、コードは遅延初期化を伴う2つの`let`バインディングが必要で、`Box`ベースのバージョンよりも多くの可動部分がありました：
 
 ```rust,ignore
 // We still need to ascribe the type for dynamic dispatch.
@@ -61,29 +50,19 @@ let readable: Box<dyn io::Read> = if arg == "-" {
 // Read from `readable` here.
 ```
 
-Luckily, this disadvantage is now gone. Yay!
+幸いにも、この欠点は今では解消されました。やった！
 
-## Discussion
+## 議論
 
-Since Rust 1.79.0, the compiler will automatically extend the lifetimes of
-temporary values within `&` or `&mut` as long as possible within the scope of
-the function.
+Rust 1.79.0以降、コンパイラは`&`または`&mut`内の一時的な値のライフタイムを、関数のスコープ内で可能な限り自動的に延長します。
 
-This means we can simply use a `&mut` value here without worrying about placing
-the contents into some `let` binding (which would have been needed for deferred
-initialization, which was the solution used before that change).
+これは、遅延初期化のために必要だった`let`バインディングにコンテンツを配置することを心配せずに、単に`&mut`値をここで使用できることを意味します（これはその変更前に使用されていた解決策でした）。
 
-We still have a place for each value (even if that place is temporary), the
-compiler knows the size of each value and each borrowed value outlives all
-references borrowed from it.
+各値には依然として場所があり（たとえその場所が一時的であっても）、コンパイラは各値のサイズを把握しており、各借用値はそれから借用されたすべての参照よりも長生きします。
 
-## See also
+## 参照
 
-- [Finalisation in destructors](dtor-finally.md) and
-  [RAII guards](../patterns/behavioural/RAII.md) can benefit from tight control
-  over lifetimes.
-- For conditionally filled `Option<&T>`s of (mutable) references, one can
-  initialize an `Option<T>` directly and use its [`.as_ref()`] method to get an
-  optional reference.
+- [デストラクタでのファイナライゼーション](dtor-finally.md)および[RAIIガード](../patterns/behavioural/RAII.md)は、ライフタイムの厳密な制御から恩恵を受けることができます。
+- （可変）参照の条件付きで埋められた`Option<&T>`の場合、`Option<T>`を直接初期化し、その[`.as_ref()`]メソッドを使用してオプショナルな参照を取得できます。
 
 [`.as_ref()`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref


### PR DESCRIPTION
## 概要

`src/idioms/on-stack-dyn-dispatch.md` を日本語に翻訳しました。

## 変更内容

- タイトルとすべてのセクションヘッダーを翻訳
- すべての説明テキストを適切な技術用語で翻訳
- コードブロックは未変更のまま保持
- すべてのリンクとファイルパスを保持

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)