### PR TITLE
翻訳: Strategy (別名 Policy) パターンを日本語に翻訳

### DIFF
--- a/src/patterns/behavioural/strategy.md
+++ b/src/patterns/behavioural/strategy.md
@@ -1,37 +1,20 @@
-# Strategy (aka Policy)
+# Strategy (別名 Policy)
 
-## Description
+## 説明
 
-The [Strategy design pattern](https://en.wikipedia.org/wiki/Strategy_pattern) is
-a technique that enables separation of concerns. It also allows to decouple
-software modules through
-[Dependency Inversion](https://en.wikipedia.org/wiki/Dependency_inversion_principle).
+[Strategyデザインパターン](https://en.wikipedia.org/wiki/Strategy_pattern)は、関心の分離を可能にする技術です。また、[依存性逆転の原則](https://en.wikipedia.org/wiki/Dependency_inversion_principle)を通じてソフトウェアモジュールを疎結合にすることもできます。
 
-The basic idea behind the Strategy pattern is that, given an algorithm solving a
-particular problem, we define only the skeleton of the algorithm at an abstract
-level, and we separate the specific algorithm’s implementation into different
-parts.
+Strategyパターンの基本的な考え方は、特定の問題を解決するアルゴリズムが与えられたとき、抽象レベルでアルゴリズムの骨格のみを定義し、具体的なアルゴリズムの実装を異なる部分に分離することです。
 
-In this way, a client using the algorithm may choose a specific implementation,
-while the general algorithm workflow remains the same. In other words, the
-abstract specification of the class does not depend on the specific
-implementation of the derived class, but specific implementation must adhere to
-the abstract specification. This is why we call it "Dependency Inversion".
+この方法により、アルゴリズムを使用するクライアントは特定の実装を選択できますが、一般的なアルゴリズムのワークフローは同じままです。言い換えれば、クラスの抽象仕様は派生クラスの具体的な実装に依存しませんが、具体的な実装は抽象仕様に従う必要があります。これが「依存性逆転」と呼ばれる理由です。
 
-## Motivation
+## 動機
 
-Imagine we are working on a project that generates reports every month. We need
-the reports to be generated in different formats (strategies), e.g., in `JSON`
-or `Plain Text` formats. But things vary over time, and we don't know what kind
-of requirement we may get in the future. For example, we may need to generate
-our report in a completely new format, or just modify one of the existing
-formats.
+毎月レポートを生成するプロジェクトに取り組んでいるとします。レポートをさまざまな形式（戦略）で生成する必要があります。例えば、`JSON`や`プレーンテキスト`形式などです。しかし、状況は時間とともに変化し、将来どのような要件が発生するかわかりません。例えば、まったく新しい形式でレポートを生成する必要があるかもしれませんし、既存の形式の1つを単に修正するだけかもしれません。
 
-## Example
+## 例
 
-In this example our invariants (or abstractions) are `Formatter` and `Report`,
-while `Text` and `Json` are our strategy structs. These strategies have to
-implement the `Formatter` trait.
+この例では、`Formatter`と`Report`が不変条件（または抽象）であり、`Text`と`Json`が戦略構造体です。これらの戦略は`Formatter`トレイトを実装する必要があります。
 
 ```rust
 use std::collections::HashMap;
@@ -95,43 +78,28 @@ fn main() {
 }
 ```
 
-## Advantages
+## 利点
 
-The main advantage is separation of concerns. For example, in this case `Report`
-does not know anything about specific implementations of `Json` and `Text`,
-whereas the output implementations does not care about how data is preprocessed,
-stored, and fetched. The only thing they have to know is a specific trait to
-implement and its method defining the concrete algorithm implementation
-processing the result, i.e., `Formatter` and `format(...)`.
+主な利点は関心の分離です。例えば、この場合、`Report`は`Json`と`Text`の具体的な実装について何も知りませんし、出力実装はデータがどのように前処理され、保存され、取得されるかを気にしません。彼らが知る必要があるのは、実装すべき特定のトレイトと、結果を処理する具体的なアルゴリズム実装を定義するそのメソッド、つまり`Formatter`と`format(...)`だけです。
 
-## Disadvantages
+## 欠点
 
-For each strategy there must be implemented at least one module, so number of
-modules increases with number of strategies. If there are many strategies to
-choose from then users have to know how strategies differ from one another.
+各戦略に対して少なくとも1つのモジュールを実装する必要があるため、戦略の数とともにモジュールの数も増加します。選択できる戦略が多数ある場合、ユーザーは戦略がどのように異なるかを知る必要があります。
 
-## Discussion
+## 議論
 
-In the previous example all strategies are implemented in a single file. Ways of
-providing different strategies includes:
+前の例では、すべての戦略が単一ファイルに実装されています。異なる戦略を提供する方法には次のものがあります：
 
-- All in one file (as shown in this example, similar to being separated as
-  modules)
-- Separated as modules, E.g. `formatter::json` module, `formatter::text` module
-- Use compiler feature flags, E.g. `json` feature, `text` feature
-- Separated as crates, E.g. `json` crate, `text` crate
+- すべて1つのファイルに（この例で示したように、モジュールとして分離するのと同様）
+- モジュールとして分離、例：`formatter::json`モジュール、`formatter::text`モジュール
+- コンパイラの機能フラグを使用、例：`json`機能、`text`機能
+- クレートとして分離、例：`json`クレート、`text`クレート
 
-Serde crate is a good example of the `Strategy` pattern in action. Serde allows
-[full customization](https://serde.rs/custom-serialization.html) of the
-serialization behavior by manually implementing `Serialize` and `Deserialize`
-traits for our type. For example, we could easily swap `serde_json` with
-`serde_cbor` since they expose similar methods. Having this makes the helper
-crate `serde_transcode` much more useful and ergonomic.
+Serdeクレートは、`Strategy`パターンの良い例です。Serdeは、型に対して`Serialize`と`Deserialize`トレイトを手動で実装することで、シリアライゼーション動作の[完全なカスタマイズ](https://serde.rs/custom-serialization.html)を可能にします。例えば、`serde_json`と`serde_cbor`は同様のメソッドを公開しているため、簡単に交換できます。これにより、ヘルパークレート`serde_transcode`がより便利で人間工学的になります。
 
-However, we don't need to use traits in order to design this pattern in Rust.
+しかし、Rustでこのパターンを設計するためにトレイトを使用する必要はありません。
 
-The following toy example demonstrates the idea of the Strategy pattern using
-Rust `closures`:
+以下のおもちゃの例は、Rustの`クロージャ`を使用したStrategyパターンのアイデアを示しています：
 
 ```rust
 struct Adder;
@@ -161,7 +129,7 @@ fn main() {
 }
 ```
 
-In fact, Rust already uses this idea for `Options`'s `map` method:
+実際、Rustはすでに`Options`の`map`メソッドでこのアイデアを使用しています：
 
 ```rust
 fn main() {
@@ -175,7 +143,7 @@ fn main() {
 }
 ```
 
-## See also
+## 参照
 
 - [Strategy Pattern](https://en.wikipedia.org/wiki/Strategy_pattern)
 - [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection)


### PR DESCRIPTION
## 変更内容

- src/patterns/behavioural/strategy.mdを英語から日本語に翻訳
- コードブロックは元のまま保持
- リンクとパスは変更なし
- 技術用語は適切に翻訳

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)