### PR TITLE
翻訳: Prefer small crates を日本語に翻訳

### DIFF
--- a/src/patterns/structural/small-crates.md
+++ b/src/patterns/structural/small-crates.md
@@ -1,47 +1,31 @@
-# Prefer small crates
+# 小さなクレートを好む
 
-## Description
+## 説明
 
-Prefer small crates that do one thing well.
+一つのことをうまく行う小さなクレートを好みましょう。
 
-Cargo and crates.io make it easy to add third-party libraries, much more so than
-in say C or C++. Moreover, since packages on crates.io cannot be edited or
-removed after publication, any build that works now should continue to work in
-the future. We should take advantage of this tooling, and use smaller, more
-fine-grained dependencies.
+CargoとCrates.ioは、サードパーティライブラリの追加を容易にします。これはCやC++などと比べてはるかに簡単です。さらに、crates.io上のパッケージは公開後に編集や削除ができないため、現在動作しているビルドは将来も動作し続けるはずです。このツールの利点を活用し、より小さく、より細分化された依存関係を使用すべきです。
 
-## Advantages
+## 利点
 
-- Small crates are easier to understand, and encourage more modular code.
-- Crates allow for re-using code between projects. For example, the `url` crate
-  was developed as part of the Servo browser engine, but has since found wide
-  use outside the project.
-- Since the compilation unit of Rust is the crate, splitting a project into
-  multiple crates can allow more of the code to be built in parallel.
+- 小さなクレートは理解しやすく、よりモジュール化されたコードを促進します。
+- クレートはプロジェクト間でコードを再利用できるようにします。例えば、`url`クレートはServoブラウザエンジンの一部として開発されましたが、その後プロジェクト外でも広く使用されるようになりました。
+- Rustのコンパイル単位はクレートであるため、プロジェクトを複数のクレートに分割することで、より多くのコードを並列でビルドできるようになります。
 
-## Disadvantages
+## 欠点
 
-- This can lead to "dependency hell", when a project depends on multiple
-  conflicting versions of a crate at the same time. For example, the `url` crate
-  has both versions 1.0 and 0.5. Since the `Url` from `url:1.0` and the `Url`
-  from `url:0.5` are different types, an HTTP client that uses `url:0.5` would
-  not accept `Url` values from a web scraper that uses `url:1.0`.
-- Packages on crates.io are not curated. A crate may be poorly written, have
-  unhelpful documentation, or be outright malicious.
-- Two small crates may be less optimized than one large one, since the compiler
-  does not perform link-time optimization (LTO) by default.
+- これは「依存関係地獄」につながる可能性があります。プロジェクトが同時に複数の競合するバージョンのクレートに依存する場合です。例えば、`url`クレートにはバージョン1.0と0.5の両方があります。`url:1.0`の`Url`と`url:0.5`の`Url`は異なる型であるため、`url:0.5`を使用するHTTPクライアントは、`url:1.0`を使用するWebスクレイパーからの`Url`値を受け入れません。
+- crates.io上のパッケージはキュレーションされていません。クレートは不適切に書かれている可能性があり、役に立たないドキュメントを持っている可能性があり、または明らかに悪意のある可能性があります。
+- コンパイラはデフォルトでリンク時最適化（LTO）を実行しないため、2つの小さなクレートは1つの大きなクレートよりも最適化されない可能性があります。
 
-## Examples
+## 例
 
-The [`url`](https://crates.io/crates/url) crate provides tools for working with
-URLs.
+[`url`](https://crates.io/crates/url)クレートは、URLを扱うためのツールを提供します。
 
-The [`num_cpus`](https://crates.io/crates/num_cpus) crate provides a function to
-query the number of CPUs on a machine.
+[`num_cpus`](https://crates.io/crates/num_cpus)クレートは、マシン上のCPU数を照会する関数を提供します。
 
-The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
-for converting `&T` to `&[T]`. (Historical example)
+[`ref_slice`](https://crates.io/crates/ref_slice)クレートは、`&T`を`&[T]`に変換するための関数を提供します。（歴史的な例）
 
-## See also
+## 関連項目
 
-- [crates.io: The Rust community crate host](https://crates.io/)
+- [crates.io: Rustコミュニティのクレートホスト](https://crates.io/)


### PR DESCRIPTION
## 概要

`src/patterns/structural/small-crates.md` を日本語に翻訳しました。

## 変更内容

- 英語から日本語への翻訳
- 技術用語の適切な翻訳
- コード参照とリンクはそのまま保持

Closes #49

———
🤖 Generated with [Claude Code](https://claude.ai/code)