### PR TITLE
翻訳: Visitorパターンのドキュメントを日本語化

### DIFF
--- a/src/patterns/behavioural/visitor.md
+++ b/src/patterns/behavioural/visitor.md
@@ -1,16 +1,12 @@
 # Visitor
 
-## Description
+## 説明
 
-A visitor encapsulates an algorithm that operates over a heterogeneous
-collection of objects. It allows multiple different algorithms to be written
-over the same data without having to modify the data (or their primary
-behaviour).
+Visitorは、異種のオブジェクトコレクションに対して動作するアルゴリズムをカプセル化します。これにより、データ(またはその主要な動作)を変更することなく、同じデータに対して複数の異なるアルゴリズムを記述できます。
 
-Furthermore, the visitor pattern allows separating the traversal of a collection
-of objects from the operations performed on each object.
+さらに、Visitorパターンは、オブジェクトコレクションの走査と各オブジェクトに対して実行される操作を分離することを可能にします。
 
-## Example
+## 例
 
 ```rust,ignore
 // The data we will visit
@@ -68,23 +64,15 @@ impl Visitor<i64> for Interpreter {
 }
 ```
 
-One could implement further visitors, for example a type checker, without having
-to modify the AST data.
+ASTデータを変更することなく、型チェッカーなどのさらなるVisitorを実装できます。
 
-## Motivation
+## 動機
 
-The visitor pattern is useful anywhere that you want to apply an algorithm to
-heterogeneous data. If data is homogeneous, you can use an iterator-like
-pattern. Using a visitor object (rather than a functional approach) allows the
-visitor to be stateful and thus communicate information between nodes.
+Visitorパターンは、異種のデータにアルゴリズムを適用したい場合に便利です。データが同種である場合は、イテレータのようなパターンを使用できます。Visitorオブジェクトを使用すること(関数型アプローチではなく)により、Visitorがステートフルになり、ノード間で情報を伝達できるようになります。
 
-## Discussion
+## 議論
 
-It is common for the `visit_*` methods to return void (as opposed to in the
-example). In that case it is possible to factor out the traversal code and share
-it between algorithms (and also to provide noop default methods). In Rust, the
-common way to do this is to provide `walk_*` functions for each datum. For
-example,
+`visit_*`メソッドがvoidを返すこと(例のように戻り値を持たない)は一般的です。その場合、走査コードを分離し、アルゴリズム間で共有することが可能です(また、デフォルトのno-opメソッドを提供することもできます)。Rustでは、これを行う一般的な方法は、各データに対して`walk_*`関数を提供することです。例えば、
 
 ```rust,ignore
 pub fn walk_expr(visitor: &mut Visitor, e: &Expr) {
@@ -102,14 +90,12 @@ pub fn walk_expr(visitor: &mut Visitor, e: &Expr) {
 }
 ```
 
-In other languages (e.g., Java) it is common for data to have an `accept` method
-which performs the same duty.
+他の言語(例えばJava)では、データに同じ役割を果たす`accept`メソッドを持たせることが一般的です。
 
-## See also
+## 参照
 
-The visitor pattern is a common pattern in most OO languages.
+Visitorパターンは、ほとんどのオブジェクト指向言語で一般的なパターンです。
 
 [Wikipedia article](https://en.wikipedia.org/wiki/Visitor_pattern)
 
-The [fold](../creational/fold.md) pattern is similar to visitor but produces a
-new version of the visited data structure.
+[fold](../creational/fold.md)パターンはVisitorと似ていますが、訪問されたデータ構造の新しいバージョンを生成します。


### PR DESCRIPTION
## 概要
`src/patterns/behavioural/visitor.md`を英語から日本語に翻訳しました。

## 変更内容
- Visitorパターンのドキュメントを日本語化
- コードブロック、リンク、パスは原文のまま保持
- 技術用語を適切に翻訳

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)