### PR TITLE
翻訳: Refactoringページを日本語に翻訳

### DIFF
--- a/src/refactoring/index.md
+++ b/src/refactoring/index.md
@@ -1,23 +1,17 @@
-# Refactoring
+# リファクタリング
 
-Refactoring is very important in relation to these topics. Just as important as
-the other topics covered here, is how to take good code and turn it into great
-code.
+リファクタリングは、これらのトピックに関連して非常に重要です。ここで取り上げる他のトピックと同じくらい重要なのは、良いコードを素晴らしいコードに変える方法です。
 
-We can use [design patterns](../patterns/index.md) to [DRY] up code and
-generalize abstractions. We must avoid
-[anti-patterns](../anti_patterns/index.md) while we do this. While they may be
-tempting to employ, their costs outweigh their benefits.
+[デザインパターン](../patterns/index.md)を使用してコードを[DRY]にし、抽象化を一般化できます。その際、[アンチパターン](../anti_patterns/index.md)を避ける必要があります。アンチパターンは使いたくなるかもしれませんが、そのコストは利益を上回ります。
 
-> Shortcuts make for long days.
+> 近道は長い一日を生む。
 
-We can also use [idioms](../idioms/index.md) to structure our code in a way that
-is understandable.
+また、[イディオム](../idioms/index.md)を使用して、理解しやすい方法でコードを構造化できます。
 
-## Tests
+## テスト
 
-Tests are of vital importance during refactoring.
+テストはリファクタリング中に極めて重要です。
 
-## Small changes
+## 小さな変更
 
 [DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself


### PR DESCRIPTION
## 概要

`src/refactoring/index.md`を英語から日本語に翻訳しました。

## 変更内容

- メインコンテンツを日本語に翻訳
- 技術用語を適切に翻訳
- リンクとパスを保持

Closes #51

———

🤖 Generated with [Claude Code](https://claude.ai/code)